### PR TITLE
Replace existing px units with rem units

### DIFF
--- a/Natours/starter/css/style.css
+++ b/Natours/starter/css/style.css
@@ -4,9 +4,9 @@
 @keyframes moveInFromLeft {
   0% {
     opacity: 0;
-    transform: translateX(-100px); }
+    transform: translateX(-10rem); }
   80% {
-    transform: translateX(10px); }
+    transform: translateX(1rem); }
   100% {
     opacity: 1;
     transform: translate(0); } }
@@ -14,20 +14,23 @@
 @keyframes moveInFromRight {
   0% {
     opacity: 0;
-    transform: translateX(100px); }
+    transform: translateX(10rem); }
   80% {
-    transform: translateX(-10px); }
+    transform: translateX(-1rem); }
   100% {
     opacity: 1;
     transform: translate(0); } }
 
+html {
+  font-size: 62.5%; }
+
 body {
   color: #777;
   font-family: "Lato", sans-serif;
-  font-size: 16px;
+  font-size: 1.6rem;
   font-weight: 400;
   line-height: 1.7;
-  padding: 30px; }
+  padding: 3rem; }
 
 *,
 *::after,
@@ -41,33 +44,33 @@ body {
   animation-name: moveInFromLeft;
   animation-timing-function: ease-out;
   display: block;
-  font-size: 60px;
+  font-size: 6rem;
   font-weight: 400;
-  letter-spacing: 35px; }
+  letter-spacing: 3.5rem; }
 
 .app-header__callout--secondary {
   animation-duration: 1s;
   animation-name: moveInFromRight;
   animation-timing-function: ease-out;
   display: block;
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 700;
-  letter-spacing: 17.4px; }
+  letter-spacing: 1.74rem; }
 
 .btn:link, .btn:visited {
-  border-radius: 100px;
+  border-radius: 10rem;
   display: inline-block;
-  padding: 15px 40px;
+  padding: 1.5rem 4rem;
   text-decoration: none;
   text-transform: uppercase;
   transition: all .2s; }
 
 .btn:hover {
-  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 1rem 2rem rgba(0, 0, 0, 0.2);
   transform: translateY(-3px); }
 
 .btn:active {
-  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.2);
   transform: translateY(-1px); }
 
 .btn--white {
@@ -84,11 +87,11 @@ body {
   position: relative;
   width: 100%; }
   .app-header__logo-wrapper {
-    left: 40px;
+    left: 4rem;
     position: absolute;
-    top: 40px; }
+    top: 4rem; }
   .app-header__logo {
-    height: 35px; }
+    height: 3.5rem; }
   .app-header__callout-wrapper {
     left: 50%;
     position: absolute;
@@ -97,5 +100,5 @@ body {
     transform: translate(-50%, -50%); }
   .app-header__callout {
     color: white;
-    margin-bottom: 60px;
+    margin-bottom: 6rem;
     text-transform: uppercase; }

--- a/Natours/starter/sass/base/_animations.scss
+++ b/Natours/starter/sass/base/_animations.scss
@@ -1,11 +1,11 @@
 @keyframes moveInFromLeft {
   0% {
     opacity: 0;
-    transform: translateX(-100px);
+    transform: translateX(-10rem);
   }
 
   80% {
-    transform: translateX(10px);
+    transform: translateX(1rem);
   }
 
   100% {
@@ -17,11 +17,11 @@
 @keyframes moveInFromRight {
   0% {
     opacity: 0;
-    transform: translateX(100px);
+    transform: translateX(10rem);
   }
 
   80% {
-    transform: translateX(-10px);
+    transform: translateX(-1rem);
   }
 
   100% {

--- a/Natours/starter/sass/base/_base.scss
+++ b/Natours/starter/sass/base/_base.scss
@@ -1,8 +1,12 @@
+html {
+  font-size: 62.5%; //1 rem = 10px; 10px/16px = 62.5%
+}
+
 body {
   color: $color-grey-dark;
   font-family: "Lato", sans-serif;
-  font-size: 16px;
+  font-size: 1.6rem;
   font-weight: 400;
   line-height: 1.7;
-  padding: 30px;
+  padding: 3rem;
 }

--- a/Natours/starter/sass/base/_typography.scss
+++ b/Natours/starter/sass/base/_typography.scss
@@ -3,9 +3,9 @@
   animation-name: moveInFromLeft;
   animation-timing-function: ease-out;
   display: block;
-  font-size: 60px;
+  font-size: 6rem;
   font-weight: 400;
-  letter-spacing: 35px;
+  letter-spacing: 3.5rem;
 }
 
 .app-header__callout--secondary {
@@ -13,7 +13,7 @@
   animation-name: moveInFromRight;
   animation-timing-function: ease-out;
   display: block;
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 700;
-  letter-spacing: 17.4px;
+  letter-spacing: 1.74rem;
 }

--- a/Natours/starter/sass/components/_button.scss
+++ b/Natours/starter/sass/components/_button.scss
@@ -1,21 +1,21 @@
 .btn {
   &:link,
   &:visited {
-    border-radius: 100px;
+    border-radius: 10rem;
     display: inline-block;
-    padding: 15px 40px;
+    padding: 1.5rem 4rem;
     text-decoration: none;
     text-transform: uppercase;
     transition: all .2s;
   }
 
   &:hover {
-    box-shadow: 0 10px 20px rgba($color-black, .2);
+    box-shadow: 0 1rem 2rem rgba($color-black, .2);
     transform: translateY(-3px);
   }
 
   &:active {
-    box-shadow: 0 5px 10px rgba($color-black, .2);
+    box-shadow: 0 .5rem 1rem rgba($color-black, .2);
     transform: translateY(-1px);
   }
 

--- a/Natours/starter/sass/layout/_header.scss
+++ b/Natours/starter/sass/layout/_header.scss
@@ -9,13 +9,13 @@
   width: 100%;
 
   &__logo-wrapper {
-    left: 40px;
+    left: 4rem;
     position: absolute;
-    top: 40px;
+    top: 4rem;
   }
 
   &__logo {
-    height: 35px;
+    height: 3.5rem;
   }
 
   &__callout-wrapper {
@@ -28,7 +28,7 @@
 
   &__callout {
     color: white;
-    margin-bottom: 60px;
+    margin-bottom: 6rem;
     text-transform: uppercase;
   }
 }


### PR DESCRIPTION
Rem units are relative to the root font size. In our case, we set the root font size to 62.5%, which, on most browsers with a default font setting of 16px, is equal to 10px. This trick is done for easier math in
multiples of 10.

There is some discussion on this particular technique and on when and how to use rem units, particularly versus em units, which are relative to the current element's font size or width, depending on which property they are used.

Some additional reading is required to better understand the rem/em, but for the sake of continuing with this project, following the instructor's current lead of using rem for all things.